### PR TITLE
feat(openclaw): add Signal sidecar, home-assistant skill, and phone secret

### DIFF
--- a/kubernetes/apps/openclaw/openclaw/app/externalsecret.yaml
+++ b/kubernetes/apps/openclaw/openclaw/app/externalsecret.yaml
@@ -17,6 +17,7 @@ spec:
         RADARR_API_KEY: "{{ .RADARR_API_KEY }}"
         SONARR_API_KEY: "{{ .SONARR_API_KEY }}"
         token: "{{ .OPENCLAW_AUTH_TOKEN }}"
+        SIGNAL_PHONE_NUMBER: "{{ .SIGNAL_PHONE_NUMBER }}"
   dataFrom:
     - extract:
         key: openclaw

--- a/kubernetes/apps/openclaw/openclaw/app/instance.yaml
+++ b/kubernetes/apps/openclaw/openclaw/app/instance.yaml
@@ -11,6 +11,8 @@ spec:
       value: "https://radarr.chestr.dev"
     - name: SONARR_URL
       value: "https://sonarr.chestr.dev"
+  skills:
+    - openclaw-homeassistant
   runtimeDeps:
     python: true
   gateway:
@@ -32,6 +34,23 @@ spec:
         signal:
           enabled: true
           dmPolicy: pairing
+  sidecars:
+    - name: signal-cli
+      image: bbernhard/signal-cli-rest-api:latest
+      env:
+        - name: PHONE_NUMBER
+          valueFrom:
+            secretKeyRef:
+              name: openclaw-secret
+              key: SIGNAL_PHONE_NUMBER
+        - name: MODE
+          value: normal
+      ports:
+        - containerPort: 8080
+      volumeMounts:
+        - name: data
+          mountPath: /home/.local/share/signal-cli
+          subPath: signal-cli
   storage:
     persistence:
       enabled: true


### PR DESCRIPTION
## Summary

- Adds `signal-cli-rest-api` sidecar container to the OpenClawInstance, wired to the existing `data` volume at a `signal-cli` subpath for persistence
- Stores `SIGNAL_PHONE_NUMBER` in the ExternalSecret, sourced from the `openclaw` item in 1Password
- Adds `openclaw-homeassistant` skill from ClawHub for Home Assistant device control

## Test plan

- [ ] Add `SIGNAL_PHONE_NUMBER: +17788194371` to the `openclaw` item in 1Password
- [ ] Verify ExternalSecret syncs and `openclaw-secret` contains the new key
- [ ] Confirm pod restarts with signal-cli sidecar running
- [ ] Register Signal number: `kubectl exec -it -n openclaw openclaw-0 -c signal-cli -- signal-cli -a +17788194371 register`
- [ ] Verify with SMS code: `kubectl exec -it -n openclaw openclaw-0 -c signal-cli -- signal-cli -a +17788194371 verify <code>`
- [ ] Confirm OpenClaw Signal channel shows as linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)