### PR TITLE
fix(qbittorrent): increase memory limit to 16Gi

### DIFF
--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -76,7 +76,7 @@ spec:
               requests:
                 cpu: 100m
               limits:
-                memory: 12Gi
+                memory: 16Gi
 
     defaultPodOptions:
       securityContext:


### PR DESCRIPTION
## Summary
- Increases qBittorrent memory limit from 12Gi to 16Gi to address OOM-related restarts

## Test plan
- [ ] Verify qBittorrent pod stabilizes after deployment and restart count stops climbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)