### PR TITLE
fix(networking): add gateway-api CRDs v1.5.1 to Flux meta

### DIFF
--- a/kubernetes/flux/meta/crds/kustomization.yaml
+++ b/kubernetes/flux/meta/crds/kustomization.yaml
@@ -1,4 +1,6 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: []
+resources:
+  # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
+  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml


### PR DESCRIPTION
## Summary

- Gateway API CRDs were installed manually and untracked by Flux/Renovate
- Envoy Gateway v1.8.0 requires CRD bundle v1.5.1 (experimental), which promotes `TLSRoute` to `gateway.networking.k8s.io/v1` — the old manually-installed v1.4.1 bundle only has it under `v1alpha2`/`v1alpha3`, causing the controller to crash on startup
- Adds the CRD URL to `flux/meta/crds/kustomization.yaml` so Flux applies it before `cluster-apps` reconciles, and the Renovate annotation enables future version bump PRs automatically

## Test plan

- [ ] Flux reconciles `cluster-meta` and applies gateway-api v1.5.1 CRDs
- [ ] Envoy Gateway HelmRelease un-stalls and v1.8.0 pod starts cleanly
- [ ] Renovate picks up future gateway-api releases and opens PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)