### PR TITLE
fix(helm): enable rbd snapshotPolicy for ceph-csi-drivers (restore VolSync)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
@@ -42,9 +42,13 @@ spec:
       rbd:
         enabled: true
         name: rook-ceph.rbd.csi.ceph.com
+        # Chart default for rbd is "none", which drops the csi-snapshotter
+        # sidecar and breaks VolSync (all backups snapshot RBD volumes).
+        snapshotPolicy: volumeSnapshot
       cephfs:
         enabled: true
         name: rook-ceph.cephfs.csi.ceph.com
+        snapshotPolicy: volumeSnapshot
       nfs:
         enabled: false
         name: rook-ceph.nfs.csi.ceph.com


### PR DESCRIPTION
## Problem

After migrating to the `ceph-csi-drivers` chart (#5689), **all VolSync backups silently stopped**. ReplicationSources have been stuck in `SyncInProgress` since the ~06-12 11:00 schedule — every `volsync-<app>-src` VolumeSnapshot sits `readyToUse=false` and never completes.

## Root cause

The `ceph-csi-drivers` chart defaults **`drivers.rbd.snapshotPolicy: "none"`** (cephfs defaults to `"volumeSnapshot"`). With `none`, the operator omits the **`csi-snapshotter` sidecar** from the rbd ctrlplugin Deployment.

Every VolSync ReplicationSource here snapshots an **RBD** (`ceph-block` / `csi-ceph-blockpool`) volume, so losing the rbd snapshotter broke all backups:
- rbd ctrlplugin containers: `csi-rbdplugin, csi-provisioner, csi-resizer, csi-attacher, log-rotator` — **no `csi-snapshotter`**
- cephfs ctrlplugin (default `volumeSnapshot`): **has** `csi-snapshotter` ✓
- `external-snapshotter-leader-rook-ceph-rbd-csi-ceph-com` lease frozen ~35h on the dead pre-migration pod
- VolumeSnapshotContents have `readyToUse: None`, `snapshotHandle: <none>` — the driver never processed them

The `snapshot-controller` itself is healthy and reconciling — it created the VSCs and is just waiting on the (missing) rbd snapshotter.

## Fix

Set `drivers.rbd.snapshotPolicy: volumeSnapshot` (and cephfs explicitly) so the operator restores the `csi-snapshotter` sidecar on the rbd ctrlplugin. Verified by render that this sets `snapshotPolicy: volumeSnapshot` on the rbd Driver CR, matching the working cephfs driver.

## Post-merge cleanup (likely needed)

Once the rbd snapshotter sidecar is back:
- The frozen `external-snapshotter-leader-rook-ceph-rbd-csi-ceph-com` lease will be taken over by the new sidecar (after the ~leaseDuration window).
- The stuck `volsync-*-src` VolumeSnapshots should get processed and go `readyToUse=true`; the in-progress ReplicationSources should then complete on their next reconcile. If any remain wedged, deleting the stuck `volsync-*-src` VolumeSnapshots will let VolSync recreate them.

I'll verify the snapshotter comes back and backups resume after merge.