### PR TITLE
fix(helm): mount SA token for multus under app-template v5

### DIFF
--- a/kubernetes/apps/networking/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/multus/app/helmrelease.yaml
@@ -45,6 +45,9 @@ spec:
               privileged: true
     defaultPodOptions:
       hostNetwork: true
+      # app-template v5 defaults automountServiceAccountToken to false; multus needs the
+      # SA token + CA cert to generate its kubeconfig (/var/run/secrets/.../ca.crt)
+      automountServiceAccountToken: true
     persistence:
       etc-cni-net-d:
         type: hostPath


### PR DESCRIPTION
multus generates its kubeconfig from the in-pod ServiceAccount token and
CA cert. app-template v5 flipped automountServiceAccountToken to false by
default, so the container crashlooped with:
  failed to create multus kubeconfig: file /var/run/secrets/kubernetes.io/serviceaccount/ca.crt not found

Enable token mounting, matching the earlier fix for homepage/gatus/dragonfly.
