### PR TITLE
feat(ai): add litellm proxy and enable memini LLM pipeline

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai
+components:
+  - ../../components/common
+resources:
+  - ./litellm-operator/ks.yaml
+  - ./litellm/ks.yaml

--- a/kubernetes/apps/ai/litellm-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/litellm-operator/app/helmrelease.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app litellm-operator
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  maxHistory: 2
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controller:
+      leaderElection:
+        enabled: true
+    webhook:
+      enabled: true
+    # No local llmkube backend in this cluster — chat is routed to a hosted
+    # provider, so don't auto-register llmkube InferenceServices as models.
+    llmkube:
+      autoRegister: false
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 128Mi

--- a/kubernetes/apps/ai/litellm-operator/app/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm-operator/app/kustomization.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/litellm-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/litellm-operator/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1beta2.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: litellm-operator
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.0.4
+  url: oci://ghcr.io/home-operations/charts/litellm-operator

--- a/kubernetes/apps/ai/litellm-operator/ks.yaml
+++ b/kubernetes/apps/ai/litellm-operator/ks.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app litellm-operator
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 30m
+  path: ./kubernetes/apps/ai/litellm-operator/app
+  prune: true
+  retryInterval: 1m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/ai/litellm/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/litellm/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: litellm
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: litellm-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Virtual key clients (memini) present as a bearer token to the proxy.
+        LITELLM_MASTER_KEY: "{{ .LITELLM_MASTER_KEY }}"
+        # Upstream provider key forwarded by litellm to OpenRouter.
+        OPENROUTER_API_KEY: "{{ .OPENROUTER_API_KEY }}"
+  dataFrom:
+    # Store both values in a 1Password item named "litellm".
+    - extract:
+        key: litellm

--- a/kubernetes/apps/ai/litellm/app/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm/app/kustomization.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./litellmproxy.yaml
+  - ./models

--- a/kubernetes/apps/ai/litellm/app/litellmproxy.yaml
+++ b/kubernetes/apps/ai/litellm/app/litellmproxy.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMProxy
+metadata:
+  name: litellm
+spec:
+  image: ghcr.io/berriai/litellm:v1.83.14-stable@sha256:d6401c001f90f3bab4bb23c5fd6d9302a7df58999ec6fa9e3f175e1f5f26544b
+  replicas: 1
+  generalSettings:
+    health_check_endpoint: /v1/health
+  routerSettings:
+    routing_strategy: simple-shuffle
+    redis_host: os.environ/REDIS_HOST
+    redis_port: os.environ/REDIS_PORT
+    num_retries: 3
+    timeout: 600
+    # Primary -> fallback when the primary model errors / times out.
+    fallbacks:
+      - memini-chat: ["memini-chat-fallback"]
+  litellmSettings:
+    drop_params: true
+    cache: true
+    cache_params:
+      type: redis
+      host: os.environ/REDIS_HOST
+      port: os.environ/REDIS_PORT
+  env:
+    - name: LITELLM_LOG
+      value: INFO
+    - name: LITELLM_MODE
+      value: PRODUCTION
+    # Dragonfly (Redis-compatible) created by the dragonfly component as
+    # "<APP>-dragonfly" — see ks.yaml postBuild APP=litellm.
+    - name: REDIS_HOST
+      value: litellm-dragonfly
+    - name: REDIS_PORT
+      value: "6379"
+    - name: LITELLM_MASTER_KEY
+      valueFrom:
+        secretKeyRef:
+          name: litellm-secret
+          key: LITELLM_MASTER_KEY
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+  service:
+    type: ClusterIP
+    port: 4000
+  route:
+    hostnames:
+      - litellm.chestr.dev
+    parentRefs:
+      - name: envoy-internal
+        namespace: networking

--- a/kubernetes/apps/ai/litellm/app/models/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm/app/models/kustomization.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./memini-chat.yaml

--- a/kubernetes/apps/ai/litellm/app/models/memini-chat.yaml
+++ b/kubernetes/apps/ai/litellm/app/models/memini-chat.yaml
@@ -1,0 +1,28 @@
+---
+# Primary chat/answer model memini calls (MEMINI_LLM_MODEL=memini-chat).
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMModel
+metadata:
+  name: memini-chat
+spec:
+  modelName: memini-chat
+  params:
+    model: openrouter/qwen/qwen3-14b
+    apiBase: https://openrouter.ai/api/v1
+    apiKeyRef:
+      name: litellm-secret
+      key: OPENROUTER_API_KEY
+---
+# Fallback used by routerSettings.fallbacks when the primary errors/times out.
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMModel
+metadata:
+  name: memini-chat-fallback
+spec:
+  modelName: memini-chat-fallback
+  params:
+    model: openrouter/qwen/qwen-2.5-7b-instruct
+    apiBase: https://openrouter.ai/api/v1
+    apiKeyRef:
+      name: litellm-secret
+      key: OPENROUTER_API_KEY

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app litellm
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/dragonfly
+  dependsOn:
+    - name: litellm-operator
+      namespace: *namespace
+    - name: dragonfly
+      namespace: database
+    - name: onepassword-store
+      namespace: external-secrets
+  interval: 30m
+  path: ./kubernetes/apps/ai/litellm/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 1m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/openclaw/memini/app/externalsecret.yaml
+++ b/kubernetes/apps/openclaw/memini/app/externalsecret.yaml
@@ -16,6 +16,11 @@ spec:
         # Shared bearer token: openclaw presents the same value (see the openclaw
         # ExternalSecret). Store it in a 1Password item named "memini".
         MEMINI_API_KEY: "{{ .MEMINI_API_KEY }}"
+        # litellm proxy virtual key (same value as the ai/litellm ExternalSecret).
+        # Stored in the 1Password item named "litellm".
+        MEMINI_LLM_API_KEY: "{{ .LITELLM_MASTER_KEY }}"
   dataFrom:
     - extract:
         key: memini
+    - extract:
+        key: litellm

--- a/kubernetes/apps/openclaw/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/openclaw/memini/app/helmrelease.yaml
@@ -36,6 +36,21 @@ spec:
                   secretKeyRef:
                     name: memini-secret
                     key: MEMINI_API_KEY
+              # Opt-in LLM pipeline: dedup/consolidation, episodic->semantic
+              # promotion, /v1/answer, and rerank. Routed through litellm
+              # (ai namespace) to a hosted OpenAI-compatible provider.
+              MEMINI_LLM_BASE_URL: "http://litellm.ai.svc.cluster.local:4000/v1"
+              MEMINI_LLM_API: openai
+              MEMINI_LLM_MODEL: memini-chat
+              MEMINI_LLM_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: memini-secret
+                    key: MEMINI_LLM_API_KEY
+              # Phase 1: rerank via the chat LLM (no extra service). A dedicated
+              # cross-encoder reranker can replace this once the chat path is
+              # validated.
+              MEMINI_RERANK: llm
     persistence:
       data:
         size: 10Gi


### PR DESCRIPTION
## Summary
Enables memini's opt-in LLM pipeline behind a local OpenAI-compatible proxy, following the bjw-s / joryirving `litellm + operator` pattern (the plan's `kubellm` is a non-deployable v0.0.1 skeleton — no image, binds 127.0.0.1, hardcodes api.openai.com).

Because the MS-01 nodes are CPU + Intel iGPU only (classic device-plugin, not the DRA driver llmkube needs), chat/answer is routed to a **hosted** provider (OpenRouter) rather than run locally. Embeddings stay on the existing in-cluster TEI `bge-small-en-v1.5`.

## What's added
- **New `ai` namespace**
  - `litellm-operator` — `oci://ghcr.io/home-operations/charts/litellm-operator:0.0.4` (`llmkube.autoRegister: false`).
  - `litellm` — `LiteLLMProxy` (single replica, port 4000, internal route `litellm.chestr.dev`) + a Dragonfly cache (`litellm-dragonfly`) via `components/dragonfly`.
  - `LiteLLMModel`s: primary `memini-chat` → `openrouter/qwen/qwen3-14b`, fallback `memini-chat-fallback` → `openrouter/qwen/qwen-2.5-7b-instruct`, wired through `routerSettings.fallbacks`.
- **memini wiring** (unchanged location, `openclaw` ns)
  - `MEMINI_LLM_BASE_URL=http://litellm.ai.svc.cluster.local:4000/v1`, `MEMINI_LLM_API=openai`, `MEMINI_LLM_MODEL=memini-chat`, `MEMINI_LLM_API_KEY` (litellm master key), `MEMINI_RERANK=llm`.
  - Embeddings (TEI bge-small, 384-dim) untouched.

## Required secret
1Password item **`litellm`** with `LITELLM_MASTER_KEY` (proxy virtual key) and `OPENROUTER_API_KEY` (upstream key). Already created. memini's ExternalSecret reads the master key from the same item.

## Decisions / phase 2
- `MEMINI_RERANK=llm` for now (no extra service). A dedicated cross-encoder reranker (`llama-server --rerank`, Qwen3-Reranker-0.6B) is deferred per the plan's "add rerank after the chat path is stable."
- Model ids are trivially editable in `litellm/app/models/memini-chat.yaml`.

## Validation
1. Reconcile; watch `litellm-operator` HR → `litellm-dragonfly` → `litellm` proxy Ready → memini rolls with new env.
2. `curl -H "Authorization: Bearer <master-key>" .../v1/models` then a `/v1/chat/completions` to `memini-chat`.
3. memini `/healthz`, then `/v1/answer`; confirm write-time consolidation produces LLM-backed updates.

## Notes
- `litellm-operator` chart values and the `LiteLLMProxy`/`LiteLLMModel` CRD fields are mirrored from bjw-s's live repo; worth watching the operator + proxy reconcile on first apply.