### PR TITLE
fix(networking): allow code-server port 12321 to openclaw

### DIFF
--- a/kubernetes/apps/ai/openclaw/app/networkpolicy.yaml
+++ b/kubernetes/apps/ai/openclaw/app/networkpolicy.yaml
@@ -17,6 +17,9 @@ spec:
       ports:
         - protocol: TCP
           port: 18789
+        # code-server sidecar (openclaw-code.chestr.dev)
+        - protocol: TCP
+          port: 12321
 ---
 # Cross-node Envoy traffic gets SNATed to the node IP. All 3 nodes are control
 # plane, so Cilium classifies their IPs as kube-apiserver. This allows that
@@ -36,6 +39,11 @@ spec:
       toPorts:
         - ports:
             - port: "18789"
+              protocol: TCP
+            # code-server sidecar (openclaw-code.chestr.dev). Envoy runs on
+            # m1/m2 while openclaw is on m0, so this cross-node (SNATed) path
+            # is what actually gates the gateway -> code-server traffic.
+            - port: "12321"
               protocol: TCP
   # Egress allowlist. The kube-mcp sidecar (cluster-admin) needs the kube-apiserver
   # entity, which Cilium does NOT cover under default-allow egress — without this


### PR DESCRIPTION
## Problem
`openclaw-code.chestr.dev` (the code-server sidecar) was unreachable, while `openclaw.chestr.dev` (gateway, 18789) worked.

## Root cause
openclaw's `NetworkPolicy` and `CiliumNetworkPolicy` both only opened **18789**; port **12321** (code-server) was never allowed. Envoy-internal runs on **m1/m2** while the openclaw pod is on **m0**, so Envoy→pod traffic is cross-node and SNATed to the node IP (a `kube-apiserver` entity in Cilium) — meaning the **CiliumNetworkPolicy** is what actually gates this path. Pre-existing latent bug, surfaced after the namespace move.

## Fix
Add `12321/TCP` to both policies. Verified: route is Accepted/ResolvedRefs, Service exposes 12321, and code-server answers `HTTP 302` (login) inside the pod. Already applied live to unblock; this commits it to GitOps.