### PR TITLE
fix(observability): point silence operator at existing alertmanager

### DIFF
--- a/kubernetes/apps/observability/silence-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/silence-operator/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
       config:
         alertmanager:
           service:
-            address: http://vmalertmanager-stack.observability.svc.cluster.local:9093
+            address: http://alertmanager-operated.observability.svc.cluster.local:9093
     rbac:
       create: true
     extraDeploy:


### PR DESCRIPTION
The silence-operator HelmRelease was still configured to use vmalertmanager-stack.observability.svc.cluster.local, but the cluster uses alertmanager-operated.\n\nThis updates the operator to the existing Alertmanager service so silence reconciliation can work again.